### PR TITLE
reflecting BC / negative_vel as explicit ndarray

### DIFF
--- a/sailfish/solvers/srhd_1d.py
+++ b/sailfish/solvers/srhd_1d.py
@@ -342,7 +342,7 @@ class Solver(SolverBase):
             pc[-ng:] = pr[+ng : +2 * ng]
 
             def negative_vel(p):
-                return [p[0], -p[1], p[2], p[3]]
+                return self.xp.asarray([p[0], -p[1], p[2], p[3]])
 
             if patch_index == 0:
                 if bcl == BC_OUTFLOW:

--- a/sailfish/solvers/srhd_2d.py
+++ b/sailfish/solvers/srhd_2d.py
@@ -373,7 +373,7 @@ class Solver(SolverBase):
             pc[-ng:] = pr[+ng : +2 * ng]
 
             def negative_vel(p):
-                return [p[0], -p[1], p[2], p[3]]
+                return self.xp.asarray([p[0], -p[1], p[2], p[3]])
 
             if patch_index == 0:
                 if bcl == BC_OUTFLOW:


### PR DESCRIPTION
CUPY expects explicit cupy.ndarray objects, so we convert the primitives in the reflecting zones from python lists to the explicit ndarray object that corresponds to its respective numpy / cupy module load. 