### PR TITLE
explicit deviceSynchronize called on context exit

### DIFF
--- a/sailfish/driver.py
+++ b/sailfish/driver.py
@@ -295,7 +295,6 @@ def simulate(driver):
     This function is a generator: it yields its state at a sequence of
     pause points, defined by the `events` dictionary.
     """
-
     from time import perf_counter
     from sailfish import __version__ as version
     from sailfish.kernel.system import configure_build, log_system_info, measure_time
@@ -480,14 +479,14 @@ def simulate(driver):
         if end_time is not None and user_time >= end_time:
             break
 
-        with measure_time() as fold_time:
+        with measure_time(mode) as fold_time:
             for _ in range(fold):
                 if dt is None or (iteration % new_timestep_cadence == 0):
                     dx = mesh.min_spacing(siml_time)
                     dt = dx / solver.maximum_wavespeed() * cfl_number
                 solver.advance(dt)
                 iteration += 1
-
+                
         Mzps = mesh.num_total_zones / fold_time() * 1e-6 * fold
         main_logger.info(
             f"[{iteration:04d}] t={user_time:0.3f} dt={dt:.3e} Mzps={Mzps:.3f}"

--- a/sailfish/kernel/library.py
+++ b/sailfish/kernel/library.py
@@ -169,7 +169,7 @@ class Library:
         logger.info(f"debug mode {'enabled' if debug else 'disabled'}")
         logger.info(f"prepare {name} for {mode} execution")
 
-        with measure_time() as prep_time:
+        with measure_time(mode) as prep_time:
             self.debug = debug
             self.cpu_mode = mode != "gpu"
             self.api = parse_api(code)

--- a/sailfish/kernel/system.py
+++ b/sailfish/kernel/system.py
@@ -154,7 +154,7 @@ def log_system_info(mode):
 
 
 @contextlib.contextmanager
-def measure_time() -> float:
+def measure_time(mode: str) -> float:
     """
     A context manager to measure the execution time of a piece of code.
 
@@ -166,5 +166,13 @@ def measure_time() -> float:
             expensive_function()
         print(f"execution took {duration()} seconds")
     """
-    start = time.perf_counter()
-    yield lambda: time.perf_counter() - start
+    deviceSynchronize = lambda *args: None 
+    if mode == 'gpu':
+        from cupy.cuda.runtime import deviceSynchronize
+        
+    try:
+        start = time.perf_counter()
+        yield lambda: time.perf_counter() - start
+    finally:
+        deviceSynchronize()
+            


### PR DESCRIPTION
Once `finally` block of execution context is reached, explicitly sync all devices for accurate GPU event-time calculations. 